### PR TITLE
core: check Chain Attack using Penalty System

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -51,6 +51,8 @@ var (
 	blockValidationTimer = metrics.NewRegisteredTimer("chain/validation", nil)
 	blockExecutionTimer  = metrics.NewRegisteredTimer("chain/execution", nil)
 	blockWriteTimer      = metrics.NewRegisteredTimer("chain/write", nil)
+	blockReorgAddMeter   = metrics.NewRegisteredMeter("chain/reorg/drop", nil)
+	blockReorgDropMeter  = metrics.NewRegisteredMeter("chain/reorg/add", nil)
 
 	ErrNoGenesis = errors.New("Genesis not found in chain")
 )
@@ -1134,14 +1136,6 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 
 	block, err := it.next()
 
-	// Penalty System to check delayed chain
-	err2 := bc.CheckDelayedChain(chain)
-	if err2 != nil {
-		stats.ignored += len(it.chain)
-		bc.reportBlock(block, nil, err2)
-		return it.index, events, coalescedLogs, err2
-	}
-
 	switch {
 	// First block is pruned, insert as sidechain and reorg only if TD grows enough
 	case err == consensus.ErrPrunedAncestor:
@@ -1224,6 +1218,10 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		status, err := bc.WriteBlockWithState(block, receipts, state)
 		t3 := time.Now()
 		if err != nil {
+			if err == ErrDelayTooHigh {
+				stats.ignored += len(it.chain)
+				bc.reportBlock(block, nil, err)
+			}
 			return it.index, events, coalescedLogs, err
 		}
 		blockInsertTimer.UpdateSince(start)
@@ -1467,11 +1465,24 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 	}
 	// Ensure the user sees large reorgs
 	if len(oldChain) > 0 && len(newChain) > 0 {
-		logFn := log.Debug
-		if len(oldChain) > 63 {
+		logFn := log.Info
+		msg := "Chain split detected"
+		if len(oldChain) < 10 {
+			logFn = log.Debug
+			msg = "Chain reorg detected"
+		} else if len(oldChain) >= 20 {
 			logFn = log.Warn
 		}
-		logFn("Chain split detected", "number", commonBlock.Number(), "hash", commonBlock.Hash(),
+
+		// Penalty System to check delayed chain
+		err := bc.CheckDelayedChain(newChain, false, true)
+		if err == ErrDelayTooHigh {
+			return err
+		}
+
+		blockReorgAddMeter.Mark(int64(len(newChain)))
+		blockReorgDropMeter.Mark(int64(len(oldChain)))
+		logFn(msg, "number", commonBlock.Number(), "hash", commonBlock.Hash(),
 			"drop", len(oldChain), "dropfrom", oldChain[0].Hash(), "add", len(newChain), "addfrom", newChain[0].Hash())
 	} else {
 		log.Error("Impossible reorg, please file an issue", "oldnum", oldBlock.Number(), "oldhash", oldBlock.Hash(), "newnum", newBlock.Number(), "newhash", newBlock.Hash())

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1137,8 +1137,9 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 	// Penalty System to check delayed chain
 	err2 := bc.CheckDelayedChain(chain)
 	if err2 != nil {
-		fmt.Println(err2.Error())
-		err = err2
+		stats.ignored += len(it.chain)
+		bc.reportBlock(block, nil, err2)
+		return it.index, events, coalescedLogs, err2
 	}
 
 	switch {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1129,10 +1129,19 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 	abort, results := bc.engine.VerifyHeaders(bc, headers, seals)
 	defer close(abort)
 
+	// check 51% Attack
+	errChain := bc.CheckChainForAttack(chain)
+	if errChain != nil {
+		fmt.Println(errChain.Error())
+	}
+
 	// Peek the error for the first block to decide the directing import logic
 	it := newInsertIterator(chain, results, bc.Validator())
 
 	block, err := it.next()
+	if errChain != nil {
+		err = errChain
+	}
 	switch {
 	// First block is pruned, insert as sidechain and reorg only if TD grows enough
 	case err == consensus.ErrPrunedAncestor:

--- a/core/error.go
+++ b/core/error.go
@@ -32,4 +32,7 @@ var (
 	// ErrNonceTooHigh is returned if the nonce of a transaction is higher than the
 	// next one expected based on the local chain.
 	ErrNonceTooHigh = errors.New("nonce too high")
+
+	// ErrDelayTooHigh is returned when the delay between the blocks in the presented chain is too high.
+	ErrDelayTooHigh = errors.New("Chain delay too high")
 )

--- a/core/penaltysystem.go
+++ b/core/penaltysystem.go
@@ -1,0 +1,137 @@
+// Copyright 2018 The go-ethereum Authors
+// Copyright 2018 The Pirl Team <dev@pirl.io>
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package core implements the Penalty System proposed by Pirl Team
+package core
+
+import (
+	"errors"
+	"sort"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+var syncStatus bool
+
+const (
+	Author = "Original Author: The Pirl Team"
+)
+
+// CheckChainForAttack will check possible 51% attack.
+// Copyright: 2018 Pirl Sprl
+// Description: CheckChainForAttack penalize newily inserted blocks.
+// The amount of penalty blocks assigned depends on the amount of blocks that the malicious miner mined in private.
+func (bc *BlockChain) CheckChainForAttack(blocks types.Blocks) error {
+	err := errors.New("")
+	err = nil
+	penalties := make(map[uint64]int64)
+	tipOfTheMainChain := bc.CurrentBlock().NumberU64()
+
+	if !syncStatus {
+		syncStatus = bc.CurrentBlock().NumberU64() == blocks[0].NumberU64()-1
+	}
+
+	if syncStatus && len(blocks) > int(params.DelayedBlockLength) && bc.CurrentBlock().NumberU64() > uint64(params.PenaltySystemBlock) {
+		for _, b := range blocks {
+			penalties[b.NumberU64()] = penaltyForBlock(tipOfTheMainChain, b.NumberU64())
+		}
+	} else {
+		return nil
+	}
+
+	p := make(PairList, len(penalties))
+	i := 0
+	for k, v := range penalties {
+		p[i] = Pair{k, v}
+		i++
+	}
+	sort.Sort(p)
+	var penalty int64
+	for _, v := range p {
+		penalty += v.Value
+	}
+
+	multi := difficultyWeight(bc.CurrentBlock().Difficulty().Uint64())
+	penalty = penalty * int64(multi)
+
+	if penalty < 0 {
+		penalty = 0
+	}
+	context := []interface{}{
+		"synced", syncStatus, "number", tipOfTheMainChain, "incoming_number", blocks[0].NumberU64() - 1, "penalty", penalty, "implementation", Author,
+	}
+
+	log.Info("Checking the legitimity of the chain", context...)
+
+	if penalty > 0 {
+		context := []interface{}{
+			"penalty", penalty,
+		}
+		log.Error("Malicious Chain! We should reject it", context...)
+		err = ErrDelayTooHigh
+	}
+
+	if penalty == 0 {
+		err = nil
+	}
+
+	return err
+}
+
+func penaltyForBlock(tipOfTheMainChain, incomingBlock uint64) int64 {
+	if incomingBlock < tipOfTheMainChain {
+		return int64(tipOfTheMainChain - incomingBlock)
+	}
+	if incomingBlock == tipOfTheMainChain {
+		return 0
+	}
+	if incomingBlock > tipOfTheMainChain {
+		return -1
+	}
+	return 0
+}
+
+func difficultyWeight(diff uint64) uint64 {
+	if diff <= 500000000 {
+		return 5
+	}
+	if diff >= 500000000 && diff < 20000000000 {
+		return 4
+	}
+	if diff >= 20000000000 && diff < 30000000000 {
+		return 3
+	}
+	if diff >= 30000000000 && diff < 50000000000 {
+		return 2
+	}
+	return 1
+}
+
+// A data structure to hold key/value pairs
+type Pair struct {
+	Key   uint64
+	Value int64
+}
+
+// A slice of pairs that implements sort.Interface to sort by values
+type PairList []Pair
+
+func (p PairList) Len() int           { return len(p) }
+func (p PairList) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p PairList) Less(i, j int) bool { return p[i].Key < p[j].Key }

--- a/core/penaltysystem.go
+++ b/core/penaltysystem.go
@@ -19,119 +19,95 @@
 package core
 
 import (
-	"errors"
-	"sort"
-
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/core/types"
 )
 
-var syncStatus bool
+var syncing bool
 
 const (
-	Author = "Original Author: The Pirl Team"
+	description = "Penalty System (based on the PirlGuard by Pirl Team)"
 )
 
-// CheckChainForAttack will check possible 51% attack.
-// Copyright: 2018 Pirl Sprl
-// Description: CheckChainForAttack penalize newily inserted blocks.
-// The amount of penalty blocks assigned depends on the amount of blocks that the malicious miner mined in private.
-func (bc *BlockChain) CheckChainForAttack(blocks types.Blocks) error {
-	err := errors.New("")
-	err = nil
-	penalties := make(map[uint64]int64)
-	tipOfTheMainChain := bc.CurrentBlock().NumberU64()
+// CheckDelayedChain will check possible 51% attack.
+// Penalty System penalize newly inserted blocks.
+// The amount of penalty depends on the amount of blocks mined by the malicious miner privatly.
+func (bc *BlockChain) CheckDelayedChain(blocks types.Blocks) error {
+	current := bc.CurrentBlock().NumberU64()
 
-	if !syncStatus {
-		syncStatus = bc.CurrentBlock().NumberU64() == blocks[0].NumberU64()-1
+	if !syncing {
+		head := rawdb.ReadHeadBlockHash(bc.db)
+		if head == (common.Hash{}) {
+			// Corrupt or empty database.
+			return nil
+		}
+		// Get current block
+		currentBlock := bc.GetBlockByHash(head)
+		if currentBlock == nil {
+			// Corrupt or empty database.
+			return nil
+		}
+		// Get current fast block
+		currentFastBlock := bc.CurrentFastBlock()
+
+		// Setup sync status
+		syncing = currentFastBlock.NumberU64() == currentBlock.NumberU64()
+		log.Info("sync status", "sync", syncing)
 	}
 
-	if syncStatus && len(blocks) > int(params.DelayedBlockLength) && bc.CurrentBlock().NumberU64() > uint64(params.PenaltySystemBlock) {
-		for _, b := range blocks {
-			penalties[b.NumberU64()] = penaltyForBlock(tipOfTheMainChain, b.NumberU64())
+	var penalty uint64
+	if syncing && len(blocks) > int(params.DelayedBlockLength) && current > uint64(params.PenaltySystemBlock) {
+		context := []interface{}{
+			"sync status", syncing, "description", description,
 		}
+		log.Info("Checking the legitimity of the chain", context...)
+
+		penalty = bc.penaltyForBlocks(blocks)
 	} else {
 		return nil
 	}
 
-	p := make(PairList, len(penalties))
-	i := 0
-	for k, v := range penalties {
-		p[i] = Pair{k, v}
-		i++
-	}
-	sort.Sort(p)
-	var penalty int64
-	for _, v := range p {
-		penalty += v.Value
-	}
-
-	multi := difficultyWeight(bc.CurrentBlock().Difficulty().Uint64())
-	penalty = penalty * int64(multi)
-
-	if penalty < 0 {
-		penalty = 0
-	}
-	context := []interface{}{
-		"synced", syncStatus, "number", tipOfTheMainChain, "incoming_number", blocks[0].NumberU64() - 1, "penalty", penalty, "implementation", Author,
-	}
-
-	log.Info("Checking the legitimity of the chain", context...)
-
-	if penalty > 0 {
+	if penalty >= params.DelayedBlockLength*(params.DelayedBlockLength+1)/2 {
 		context := []interface{}{
 			"penalty", penalty,
 		}
 		log.Error("Malicious Chain! We should reject it", context...)
-		err = ErrDelayTooHigh
+		bc.setBadHash(blocks[0], params.DelayedBlockLength)
+		return ErrDelayTooHigh
 	}
 
-	if penalty == 0 {
-		err = nil
-	}
-
-	return err
+	return nil
 }
 
-func penaltyForBlock(tipOfTheMainChain, incomingBlock uint64) int64 {
-	if incomingBlock < tipOfTheMainChain {
-		return int64(tipOfTheMainChain - incomingBlock)
+func (bc *BlockChain) penaltyForBlocks(blocks types.Blocks) uint64 {
+	var sum, penalty uint64
+	current := bc.CurrentBlock().NumberU64()
+	for _, b := range blocks {
+		if current >= b.NumberU64() {
+			penalty = current - b.NumberU64()
+		} else {
+			penalty = 0
+		}
+		sum += penalty
+		context := []interface{}{
+			"head", current, "number", b.NumberU64(), "penalty", penalty, "sum", sum,
+		}
+
+		log.Warn("Penalty check", context...)
 	}
-	if incomingBlock == tipOfTheMainChain {
-		return 0
-	}
-	if incomingBlock > tipOfTheMainChain {
-		return -1
-	}
-	return 0
+	return sum
 }
 
-func difficultyWeight(diff uint64) uint64 {
-	if diff <= 500000000 {
-		return 5
+func (bc *BlockChain) setBadHash(block *types.Block, minPenalty uint64) {
+	current := bc.CurrentBlock().NumberU64()
+	if current >= block.NumberU64() {
+		penalty := current - block.NumberU64()
+		if penalty >= minPenalty {
+			BadHashes[block.Header().Hash()] = true
+			log.Error("New Bad Hash", "block", block.NumberU64(), "hash", block.Header().Hash(), "penalty", penalty)
+		}
 	}
-	if diff >= 500000000 && diff < 20000000000 {
-		return 4
-	}
-	if diff >= 20000000000 && diff < 30000000000 {
-		return 3
-	}
-	if diff >= 30000000000 && diff < 50000000000 {
-		return 2
-	}
-	return 1
 }
-
-// A data structure to hold key/value pairs
-type Pair struct {
-	Key   uint64
-	Value int64
-}
-
-// A slice of pairs that implements sort.Interface to sort by values
-type PairList []Pair
-
-func (p PairList) Len() int           { return len(p) }
-func (p PairList) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-func (p PairList) Less(i, j int) bool { return p[i].Key < p[j].Key }

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -92,6 +92,6 @@ var (
 	GenesisDifficulty      = big.NewInt(131072) // Difficulty of the Genesis block.
 	MinimumDifficulty      = big.NewInt(131072) // The minimum that the difficulty may ever be.
 	DurationLimit          = big.NewInt(13)     // The decision boundary on the blocktime duration used to determine whether difficulty should go up or not.
-	PenaltySystemBlock     = int64(2000000)     // Activatation height of Penalty System.
+	PenaltySystemBlock     = int64(0)           // Activatation height of Penalty System.
 	DelayedBlockLength     = uint64(20)         // Threshold number of blocks that can be delayed.
 )

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -92,4 +92,6 @@ var (
 	GenesisDifficulty      = big.NewInt(131072) // Difficulty of the Genesis block.
 	MinimumDifficulty      = big.NewInt(131072) // The minimum that the difficulty may ever be.
 	DurationLimit          = big.NewInt(13)     // The decision boundary on the blocktime duration used to determine whether difficulty should go up or not.
+	PenaltySystemBlock     = int64(2000000)     // Activatation height of Penalty System.
+	DelayedBlockLength     = uint64(20)         // Threshold number of blocks that can be delayed.
 )


### PR DESCRIPTION
***WIP***
based on the PirlGuard by Pirl Team.

- simplified Penalty System
- remove not used `difficultyWeight()`
- remove sort (blocks are already sorted at `procFutureBlocks()` https://github.com/ethereum/go-ethereum/blob/master/core/blockchain.go#L737-L744 )
- check syncing status like as `eth.syncing`
- use `core.BadHashes` to save possible attack hash (could be extracted as `config.BadHashes`)

## Ideas
- [ ] make `core.BadHashes` configurable.
- [ ] warning system for admin/exchanges

See also
- Penalty System by Horizen(ZenCash) https://www.horizen.global/assets/files/A-Penalty-System-for-Delayed-Block-Submission-by-Horizen.pdf
- 51% Attack Mitigation Penalty System by Horizen - https://www.youtube.com/watch?v=E99wpSZs6iM
- https://github.com/Musicoin/go-musicoin/pull/99/commits/1dc249d46cf2c04e79ff341e55d0d7a0e4208762
- go-ethereum based off source for Pirl https://github.com/pirl/pirl
- original author of the PirlGuard
  - 0x1337 https://github.com/0x1337coding
  - masterdubs https://github.com/masterdubs

cc: @masterdubs, @0x1337coding
cc: @magnalucus @kimmyeonghun 